### PR TITLE
Fix Mautic forms when the plugin is not installed or not configured

### DIFF
--- a/Service/RecaptchaClient.php
+++ b/Service/RecaptchaClient.php
@@ -12,6 +12,7 @@ use GuzzleHttp\Client as GuzzleClient;
 use Mautic\CoreBundle\EventListener\CommonSubscriber;
 use Mautic\PluginBundle\Helper\IntegrationHelper;
 use MauticPlugin\MauticRecaptchaBundle\Integration\RecaptchaIntegration;
+use Mautic\PluginBundle\Integration\AbstractIntegration;
 
 class RecaptchaClient extends CommonSubscriber
 {
@@ -36,9 +37,11 @@ class RecaptchaClient extends CommonSubscriber
     {
         $integrationObject = $integrationHelper->getIntegrationObject(RecaptchaIntegration::INTEGRATION_NAME);
 
-        $keys            = $integrationObject->getKeys();
-        $this->siteKey   = $keys['site_key'];
-        $this->secretKey = $keys['secret_key'];
+        if ($integrationObject instanceof AbstractIntegration) {
+            $keys            = $integrationObject->getKeys();
+            $this->siteKey   = isset($keys['site_key']) ? $keys['site_key'] : null;
+            $this->secretKey = isset($keys['secret_key']) ? $keys['secret_key'] : null;
+        }
     }
 
     /**

--- a/Tests/RecaptchaClientTest.php
+++ b/Tests/RecaptchaClientTest.php
@@ -1,0 +1,70 @@
+<?php
+
+/*
+ * @copyright   2018 Konstantin Scheumann. All rights reserved
+ * @author      Konstantin Scheumann
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace MauticPlugin\MauticRecaptchaBundle\Tests;
+
+use PHPUnit_Framework_MockObject_MockBuilder;
+use Mautic\PluginBundle\Helper\IntegrationHelper;
+use MauticPlugin\MauticRecaptchaBundle\Integration\RecaptchaIntegration;
+use MauticPlugin\MauticRecaptchaBundle\Service\RecaptchaClient;
+
+class RecaptchaClientTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var PHPUnit_Framework_MockObject_MockBuilder|IntegrationHelper
+     */
+    private $integrationHelper;
+
+    /**
+     * @var PHPUnit_Framework_MockObject_MockBuilder|RecaptchaIntegration
+     */
+    private $integration;
+
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->integrationHelper = $this->createMock(IntegrationHelper::class);
+        $this->integration       = $this->createMock(RecaptchaIntegration::class);
+    }
+
+    public function testVerifyWhenPluginIsNotInstalled()
+    {
+        $this->integrationHelper->expects($this->once())
+            ->method('getIntegrationObject')
+            ->willReturn(null);
+
+        $this->integration->expects($this->never())
+            ->method('getKeys');
+
+        $this->createRecaptchaClient()->verify('');
+    }
+
+    public function testVerifyWhenPluginIsNotConfigured()
+    {
+        $this->integrationHelper->expects($this->once())
+            ->method('getIntegrationObject')
+            ->willReturn($this->integration);
+
+        $this->integration->expects($this->once())
+            ->method('getKeys')
+            ->willReturn(['site_key' => 'test', 'secret_key' => 'test']);
+
+        $this->createRecaptchaClient()->verify('');
+    }
+
+    /**
+     * @return RecaptchaClient
+     */
+    private function createRecaptchaClient()
+    {
+        return new RecaptchaClient(
+            $this->integrationHelper
+        );
+    }
+}


### PR DESCRIPTION
If you move the plugin to the plugins folder then try to create a new form, it will error out.

If you do install the plugin and try to create a new form it will still error out because the keys are missing.

This PR will fix that. Also added test that cover these scenarios.