### PR TITLE
Float casting on minScore field

### DIFF
--- a/Form/Type/RecaptchaType.php
+++ b/Form/Type/RecaptchaType.php
@@ -48,7 +48,7 @@ class RecaptchaType extends AbstractType
                     'class' => 'form-control',
                     'data-show-on' => '{"formfield_properties_scoreValidation_1":"checked"}'
                 ],
-                'data'       => isset($options['data']['minScore']) ? $options['data']['minScore'] : 0.8,
+                'data'       => isset($options['data']['minScore']) ? (float) $options['data']['minScore'] : 0.8,
             ]
         );
 


### PR DESCRIPTION
If the user language is set with a certain value (I tryed German, French, Spanish...) different from System Default Locale, when you try to create a reCaptcha type on forms and save it, it triggers [symfony validator](https://github.com/symfony/symfony/blob/4.4/src/Symfony/Component/Form/Extension/Core/DataTransformer/NumberToLocalizedStringTransformer.php#L107) and raises a 500 error:

`mautic.CRITICAL: Uncaught PHP Exception Symfony\Component\Form\Exception\TransformationFailedException: "Unable to transform value for property path "[minScore]": Expected a numeric."`

